### PR TITLE
Add integration tests for REST and UI endpoints

### DIFF
--- a/src/test/java/examples/rest/RoleRestControllerIT.java
+++ b/src/test/java/examples/rest/RoleRestControllerIT.java
@@ -1,0 +1,141 @@
+package examples.rest;
+
+import annotation.IntegrationTest;
+import annotation.WithMockJwt;
+import examples.domain.Role;
+import examples.dto.crud.RoleDto;
+import examples.repository.RoleRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springinfra.assets.AuthorityType;
+import org.springinfra.controller.rest.BaseRestController;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@IntegrationTest
+@WithMockJwt(username = "admin", authorities = {AuthorityType.StringFormat.ROLE_MANAGEMENT_AUTHORITY})
+class RoleRestControllerIT {
+
+    private static final String BASE_URL = BaseRestController.API_PATH_PREFIX_V1 + "/roles";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Test
+    void whenSaveRequestIsValid_thenReturnsOkResponse() throws Exception {
+        RoleDto request = buildRoleRequest();
+
+        this.mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.result.name").value("Administration"));
+    }
+
+    @Test
+    void whenSaveRequestMissingName_thenReturnsBadRequest() throws Exception {
+        RoleDto request = buildRoleRequest();
+        request.setName("");
+
+        this.mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.result", hasItem("Role name is required")));
+    }
+
+    @Test
+    void whenUpdateRequestIsValid_thenReturnsOkResponse() throws Exception {
+        Role existingRole = persistRole("Viewer");
+        RoleDto request = buildRoleRequest();
+        request.setName("Editor");
+        request.setVersion(1L);
+
+        this.mockMvc.perform(put(BASE_URL + "/{id}", existingRole.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.result.name").value("Editor"));
+    }
+
+    @Test
+    void whenUpdateRequestMissingVersion_thenReturnsBadRequest() throws Exception {
+        Role existingRole = persistRole("Viewer");
+        RoleDto request = buildRoleRequest();
+
+        this.mockMvc.perform(put(BASE_URL + "/{id}", existingRole.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.result", hasItem("version is required")));
+    }
+
+    @Test
+    void whenDeleteRequest_thenReturnsNoContent() throws Exception {
+        Role existingRole = persistRole("ToDelete");
+
+        this.mockMvc.perform(delete(BASE_URL + "/{id}", existingRole.getId()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void whenFindRequest_thenReturnsOkResponse() throws Exception {
+        Role savedRole = persistRole("Finder");
+
+        this.mockMvc.perform(get(BASE_URL + "/{id}", savedRole.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.result.name").value("Finder"));
+    }
+
+    @Test
+    void whenListRequest_thenReturnsOkResponse() throws Exception {
+        persistRole("ListRoleOne");
+        persistRole("ListRoleTwo");
+
+        this.mockMvc.perform(get(BASE_URL)
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.result", hasSize(2)))
+                .andExpect(jsonPath("$.result[*].name", hasItem("ListRoleOne")))
+                .andExpect(jsonPath("$.result[*].name", hasItem("ListRoleTwo")));
+    }
+
+    private RoleDto buildRoleRequest() {
+        RoleDto roleDto = new RoleDto();
+        roleDto.setName("Administration");
+        roleDto.setAuthorities(List.of(AuthorityType.USER_MANAGEMENT_AUTHORITY, AuthorityType.ROLE_MANAGEMENT_AUTHORITY));
+        return roleDto;
+    }
+
+    private Role persistRole(String name) {
+        Role role = new Role();
+        role.setName(name);
+        role.setAuthorities(List.of(AuthorityType.ACCOUNT_INFO_AUTHORITY));
+        return this.roleRepository.save(role);
+    }
+}

--- a/src/test/java/examples/rest/UserRestControllerIT.java
+++ b/src/test/java/examples/rest/UserRestControllerIT.java
@@ -1,0 +1,174 @@
+package examples.rest;
+
+import annotation.IntegrationTest;
+import annotation.WithMockJwt;
+import examples.assets.UserStatus;
+import examples.domain.User;
+import examples.dto.crud.UserDto;
+import examples.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springinfra.assets.AuthorityType;
+import org.springinfra.controller.rest.BaseRestController;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@IntegrationTest
+@WithMockJwt(username = "admin", authorities = {AuthorityType.StringFormat.USER_MANAGEMENT_AUTHORITY})
+class UserRestControllerIT {
+
+    private static final String BASE_URL = BaseRestController.API_PATH_PREFIX_V1 + "/users";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void whenSaveRequestIsValid_thenReturnsOkResponse() throws Exception {
+        UserDto request = buildUserRequest();
+
+        this.mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.result.firstName").value("John"));
+    }
+
+    @Test
+    void whenSaveRequestMissingFirstName_thenReturnsBadRequest() throws Exception {
+        UserDto request = buildUserRequest();
+        request.setFirstName(null);
+
+        this.mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.result", hasItem("First-Name is required")));
+    }
+
+    @Test
+    void whenUpdateRequestIsValid_thenReturnsOkResponse() throws Exception {
+        User existingUser = persistUser("Before");
+        UserDto request = buildUserRequest();
+        request.setFirstName("Updated");
+        request.setVersion(1L);
+
+        this.mockMvc.perform(put(BASE_URL + "/{id}", existingUser.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.result.firstName").value("Updated"));
+    }
+
+    @Test
+    void whenUpdateRequestMissingVersion_thenReturnsBadRequest() throws Exception {
+        User existingUser = persistUser("Before");
+        UserDto request = buildUserRequest();
+
+        this.mockMvc.perform(put(BASE_URL + "/{id}", existingUser.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.result", hasItem("version is required")));
+    }
+
+    @Test
+    void whenPatchRequestIsValid_thenReturnsOkResponse() throws Exception {
+        User existingUser = persistUser("Before");
+
+        this.mockMvc.perform(patch(BASE_URL + "/{id}", existingUser.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"firstName\":\"Patched\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.result.firstName").value("Patched"));
+    }
+
+    @Test
+    void whenPatchRequestHasUnknownField_thenReturnsBadRequest() throws Exception {
+        User existingUser = persistUser("Before");
+
+        this.mockMvc.perform(patch(BASE_URL + "/{id}", existingUser.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"notAField\":\"value\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.result", hasItem("[notAField]: Property does not exist")));
+    }
+
+    @Test
+    void whenDeleteRequest_thenReturnsNoContent() throws Exception {
+        User existingUser = persistUser("ToDelete");
+
+        this.mockMvc.perform(delete(BASE_URL + "/{id}", existingUser.getId()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void whenFindRequest_thenReturnsOkResponse() throws Exception {
+        User savedUser = persistUser("Finder");
+
+        this.mockMvc.perform(get(BASE_URL + "/{id}", savedUser.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.result.firstName").value("Finder"));
+    }
+
+    @Test
+    void whenListRequest_thenReturnsOkResponse() throws Exception {
+        persistUser("ListUserOne", "list.one@example.com");
+        persistUser("ListUserTwo", "list.two@example.com");
+
+        this.mockMvc.perform(get(BASE_URL)
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.result", hasSize(2)))
+                .andExpect(jsonPath("$.result[*].email", hasItem("list.one@example.com")))
+                .andExpect(jsonPath("$.result[*].email", hasItem("list.two@example.com")));
+    }
+
+    private UserDto buildUserRequest() {
+        UserDto userDto = new UserDto();
+        userDto.setFirstName("John");
+        userDto.setLastName("Doe");
+        userDto.setEmail("john.doe@example.com");
+        userDto.setPhone("123-456-7890");
+        userDto.setStatus(UserStatus.ACTIVE);
+        return userDto;
+    }
+
+    private User persistUser(String firstName) {
+        return persistUser(firstName, firstName.toLowerCase() + "@example.com");
+    }
+
+    private User persistUser(String firstName, String email) {
+        User user = new User();
+        user.setFirstName(firstName);
+        user.setLastName("Doe");
+        user.setEmail(email);
+        user.setPhone("123-456-7890");
+        user.setStatus(UserStatus.ACTIVE);
+        return this.userRepository.save(user);
+    }
+}

--- a/src/test/java/examples/ui/AccessDeniedUIControllerIT.java
+++ b/src/test/java/examples/ui/AccessDeniedUIControllerIT.java
@@ -1,0 +1,31 @@
+package examples.ui;
+
+import annotation.IntegrationTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@Slf4j
+@IntegrationTest
+class AccessDeniedUIControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void whenAccessDeniedPageRequested_thenReturnsViewWithRequestIp() throws Exception {
+        this.mockMvc.perform(get("/403").with(request -> {
+                    request.setRemoteAddr("192.168.1.10");
+                    return request;
+                }))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("request_ip", "192.168.1.10"))
+                .andExpect(view().name(AccessDeniedUIController.VIEW_PAGE));
+    }
+}

--- a/src/test/java/examples/ui/AccountInfoUIControllerIT.java
+++ b/src/test/java/examples/ui/AccountInfoUIControllerIT.java
@@ -1,0 +1,38 @@
+package examples.ui;
+
+import annotation.IntegrationTest;
+import annotation.WithMockJwt;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springinfra.assets.AuthorityType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@Slf4j
+@IntegrationTest
+class AccountInfoUIControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockJwt(username = "user", authorities = {AuthorityType.StringFormat.ACCOUNT_INFO_AUTHORITY})
+    void whenAuthorizedUserRequestsAccountInfo_thenReturnsView() throws Exception {
+        this.mockMvc.perform(get("/user/account"))
+                .andExpect(status().isOk())
+                .andExpect(view().name(AccountInfoUIController.VIEW_PAGE));
+    }
+
+    @Test
+    @WithMockJwt(username = "user", authorities = {AuthorityType.StringFormat.USER_MANAGEMENT_AUTHORITY})
+    void whenAuthenticatedUserWithoutAuthorityRequestsAccountInfo_thenRedirectsTo403() throws Exception {
+        this.mockMvc.perform(get("/user/account"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("/403"));
+    }
+}

--- a/src/test/java/examples/ui/IndexUIControllerIT.java
+++ b/src/test/java/examples/ui/IndexUIControllerIT.java
@@ -1,0 +1,33 @@
+package examples.ui;
+
+import annotation.IntegrationTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@Slf4j
+@IntegrationTest
+class IndexUIControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void whenRootRequest_thenReturnsIndexView() throws Exception {
+        this.mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name(IndexUIController.VIEW_PAGE));
+    }
+
+    @Test
+    void whenIndexRequest_thenReturnsIndexView() throws Exception {
+        this.mockMvc.perform(get("/index"))
+                .andExpect(status().isOk())
+                .andExpect(view().name(IndexUIController.VIEW_PAGE));
+    }
+}

--- a/src/test/java/examples/ui/LoginUIControllerIT.java
+++ b/src/test/java/examples/ui/LoginUIControllerIT.java
@@ -1,0 +1,36 @@
+package examples.ui;
+
+import annotation.IntegrationTest;
+import annotation.WithMockJwt;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@Slf4j
+@IntegrationTest
+class LoginUIControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void whenAnonymousUserRequestsLogin_thenReturnsBuiltInLoginView() throws Exception {
+        this.mockMvc.perform(get("/login"))
+                .andExpect(status().isOk())
+                .andExpect(view().name(LoginUIController.BUILT_IN_LOGIN_JSP));
+    }
+
+    @Test
+    @WithMockJwt(username = "admin")
+    void whenAuthenticatedUserRequestsLogin_thenRedirectsToIndex() throws Exception {
+        this.mockMvc.perform(get("/login"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("/"));
+    }
+}

--- a/src/test/java/examples/ui/UserManagementUIControllerIT.java
+++ b/src/test/java/examples/ui/UserManagementUIControllerIT.java
@@ -1,0 +1,39 @@
+package examples.ui;
+
+import annotation.IntegrationTest;
+import annotation.WithMockJwt;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springinfra.assets.AuthorityType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@Slf4j
+@IntegrationTest
+class UserManagementUIControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void whenAnonymousUserRequestsUserManagement_thenRedirectsToLogin() throws Exception {
+        this.mockMvc.perform(get("/admin/user-management"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("/login"));
+    }
+
+    @Test
+    @WithMockJwt(username = "admin", authorities = {AuthorityType.StringFormat.USER_MANAGEMENT_AUTHORITY})
+    void whenAuthorizedUserRequestsUserManagement_thenReturnsView() throws Exception {
+        this.mockMvc.perform(get("/admin/user-management"))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("userList"))
+                .andExpect(view().name(UserManagementUIController.VIEW_PAGE));
+    }
+}

--- a/src/test/java/org/springinfra/controller/rest/AuthenticationControllerIT.java
+++ b/src/test/java/org/springinfra/controller/rest/AuthenticationControllerIT.java
@@ -1,0 +1,72 @@
+package org.springinfra.controller.rest;
+
+import annotation.IntegrationTest;
+import examples.dto.AuthRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@IntegrationTest
+class AuthenticationControllerIT {
+
+    private static final String BASE_URL = BaseRestController.API_PATH_PREFIX_V1 + "/authenticate";
+    private static final String USERNAME = "admin";
+    private static final String PASSWORD = "password123";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        String encodedPassword = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8().encode(PASSWORD);
+        registry.add("security.idp.module", () -> "inMemoryIdentityProviderModule");
+        registry.add("security.idp.in-memory.credentials[0]",
+                () -> USERNAME + ";" + encodedPassword + ";USER_MANAGEMENT_AUTHORITY;ACCOUNT_INFO_AUTHORITY;ROLE_MANAGEMENT_AUTHORITY");
+    }
+
+    @Test
+    void whenAuthenticateRequestIsValid_thenReturnsOkResponse() throws Exception {
+        AuthRequest request = buildAuthRequest(USERNAME, PASSWORD);
+
+        this.mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.result.token").value(not(isEmptyOrNullString())));
+    }
+
+    @Test
+    void whenAuthenticateRequestHasInvalidPassword_thenReturnsUnauthorized() throws Exception {
+        AuthRequest request = buildAuthRequest(USERNAME, "wrong-password");
+
+        this.mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private AuthRequest buildAuthRequest(String username, String password) {
+        AuthRequest request = new AuthRequest();
+        request.setUsername(username);
+        request.setPassword(password);
+        return request;
+    }
+}


### PR DESCRIPTION
### Motivation
- Increase integration test coverage for REST and MVC endpoints to validate happy-paths and common failure/validation scenarios as per repository testing guidelines. 

### Description
- Added CRUD integration tests for users in `src/test/java/examples/rest/UserRestControllerIT.java` covering save, update, patch, delete, find and list flows and validation errors. 
- Added CRUD integration tests for roles in `src/test/java/examples/rest/RoleRestControllerIT.java` covering save, update, delete, find, list and validation errors. 
- Added authentication integration tests in `src/test/java/org/springinfra/controller/rest/AuthenticationControllerIT.java` that register dynamic in-memory credentials via `@DynamicPropertySource` and assert success and invalid-password flows. 
- Added UI integration tests for index, login, user-management, account-info and access-denied pages under `src/test/java/examples/ui/` validating view names, redirects and secured-page behavior using `@IntegrationTest`, `@WithMockJwt`, `MockMvc` and `ObjectMapper`. 

### Testing
- Ran `mvn test -Dtest=UserRestControllerIT,RoleRestControllerIT,AuthenticationControllerIT,IndexUIControllerIT,LoginUIControllerIT,UserManagementUIControllerIT,AccountInfoUIControllerIT,AccessDeniedUIControllerIT,CredentialRestControllerIT` to execute the new integration tests. 
- The Maven run failed due to dependency resolution (unable to download Spring Boot parent POM from Maven Central: HTTP 403), preventing the tests from executing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c15dc0af88328801938136393d49d)